### PR TITLE
Fixed #14: new parameters to set up tiler url

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,30 @@ Using the library is really easy. It accepts the following parameters to manage 
 <td></td>
 <td>No</td>
 </tr>
+
+<tr>
+<td>tiler_protocol</td>
+<td>Tiler protocol (opcional - default = 'http').</td>
+<td>No</td>
+<td></td>
+</tr>
+
+<tr>
+<td>tiler_domain</td>
+<td>Tiler domain (opcional - default = 'cartodb.com').</td>
+<td></td>
+<td>No</td>
+<td></td>
+</tr>
+
+<tr>
+<td>tiler_port</td>
+<td>Tiler port as a string (opcional - default = '80').</td>
+<td></td>
+<td>No</td>
+<td></td>
+</tr>
+
 </table>
 
 

--- a/index.html
+++ b/index.html
@@ -243,6 +243,27 @@
               <td></td>
               <td>No</td>
             </tr>
+            <tr>
+              <td><i>tiler_protocol</i></td>
+              <td>Protocol for the tiler URL. Default: <b>http</b></td>
+              <td>String</td>
+              <td></td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td><i>tiler_domain</i></td>
+              <td>Base domain of the tiler URL. Default: <b>cartodb.com</b> </td>
+              <td>String</td>
+              <td></td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td><i>tiler_port</i></td>
+              <td>Port of the tiler URL. Default: <b>80</b> </td>
+              <td>String</td>
+              <td></td>
+              <td>No</td>
+            </tr>
           </table>
 
 


### PR DESCRIPTION
Hi

This is a patch to allow new parameters during the setup of a CartoDB Layer: the tiler_protocolo, tiler_domain and tiler_port.
